### PR TITLE
fix: remove invalid character in filename on windows

### DIFF
--- a/models/video.py
+++ b/models/video.py
@@ -1,3 +1,6 @@
+import re
+
+
 class Video():
 
     def __init__(self, url: str, category: int) -> None:
@@ -5,7 +8,8 @@ class Video():
         self.category = category
 
     def set_title(self, title: str) -> None:
-        self.title = title
+        pattern = re.compile(r'[<>:"\/\\|\?\*]')
+        self.title = re.sub(pattern, "", title)
 
     def set_quality(self, id: int) -> None:
         self.quality = {

--- a/strategy/default.py
+++ b/strategy/default.py
@@ -47,7 +47,6 @@ class DefaultStrategy(BilibiliStrategy):
 
     def get_video_title(self, bs: BeautifulSoup) -> str:
         video_title = bs.find('h1').get_text()
-        video_title = video_title.replace('/', '-')
         print(video_title)
 
         return video_title


### PR DESCRIPTION
resolve #14

删除了文件名中的非法字符`<>:"/\|?*`
