### PR TITLE
feat: use ffmpeg to merge video and add download progress back

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx==0.23.1
 moviepy==1.0.3
 requests==2.32.0
 urllib3==1.26.19
+tqdm==4.66.5

--- a/strategy/bilibili_executor.py
+++ b/strategy/bilibili_executor.py
@@ -1,7 +1,10 @@
 import os
+import time
 
+import httpx
 import moviepy.editor as mp
-import urllib
+
+from tqdm import tqdm
 
 from strategy.bilibili_strategy import BilibiliStrategy
 from strategy.default import DefaultStrategy
@@ -90,39 +93,44 @@ class BilibiliDownloader():
         # urllib.request.urlretrieve(url=audio_url, filename=os.path.join(self.temp_path, audio_filename), reporthook=self._schedule)
         print("【下载音频完毕】")
 
-    def _download(self, url, filename) -> None:
-        request = urllib.request.Request(url, headers=self.headers)
-        response = urllib.request.urlopen(request).read()
-        with open(os.path.join(self.temp_path, filename), mode='wb') as f:
-            f.write(response)
+    def _download(self, url, filename, max_retries=3, retry_delay=5) -> None:
+        retries = 0
+        while retries < max_retries:
+            try:
+                # 检查文件是否已存在
+                file_size = 0
+                if os.path.exists(filename):
+                    file_size = os.path.getsize(filename)
 
-    # def _schedule(self, block_count, block_size, total_size) -> None:
-    #     '''
-    #     urllib.urlretrieve 的回调函数
-    #     :param block_count: 已经下载的数据块
-    #     :param block_size: 数据块的大小
-    #     :param total_size: 远程文件的大小
-    #     :return:
-    #     '''
-    #     # percent = 100.0 * block_count * block_size / total_size
-    #     # if percent > 100:
-    #     #     percent = 100
-    #     # s = ('#' * round(percent)).ljust(100, '-')
-    #     # sys.stdout.write("%.2f%%" % percent + '[ ' + s + ']' + '\r')
-    #     # sys.stdout.flush()
+                # 设置请求头 Range 字段，用于断点续传
+                self.headers["Range"] = f"bytes={file_size}-"
+                with httpx.stream("GET", url, headers=self.headers) as response:
+                    if response.status_code == 416:
+                        print("文件已经下载完毕")
+                        return
 
-    #     percentage = 100.0 * block_count * block_size / total_size
-    #     if percentage > 100:
-    #         percentage = 100
-    #     max_bar = 50
-    #     bar_num = int(percentage / (100 / max_bar))
-    #     progress_element = '=' * bar_num
-    #     if bar_num != max_bar:
-    #         progress_element += '>'
-    #     bar_fill = ' '
-    #     bar = progress_element.ljust(max_bar, bar_fill)
-    #     total_size_kb = total_size / 1024
-    #     print(f'[{bar}] {percentage:.2f}% ({total_size_kb:.0f}KB)\r', end='')
+                    # 总的文件大小包括已下载的部分
+                    total_size = (
+                        int(response.headers.get("content-length", 0)) + file_size
+                    )
+
+                    mode = "ab" if file_size > 0 else "wb"
+
+                    # 使用 tqdm 显示进度条
+                    with open(filename, mode) as file, tqdm(
+                        total=total_size, unit="B", unit_scale=True, initial=file_size
+                    ) as progress_bar:
+                        for chunk in response.iter_bytes():
+                            if chunk:
+                                file.write(chunk)
+                                progress_bar.update(len(chunk))  # 更新进度条
+                return # 下载成功，退出函数
+            except (httpx.RemoteProtocolError, httpx.RequestError) as e:
+                retries += 1
+                print(f"下载过程中出现错误: {e}，正在重试 ({retries}/{max_retries})...")
+                time.sleep(retry_delay)
+
+        print("下载失败，已达到最大重试次数")
 
 
 class VideoMerge():

--- a/strategy/bilibili_executor.py
+++ b/strategy/bilibili_executor.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import time
 
@@ -153,7 +154,7 @@ class VideoMerge():
             os.mkdir(self.path)
 
         # 如果 ffmpeg 存在，则用其合并视频和音频
-        if subprocess.run("ffmpeg -version").returncode == 0:
+        if shutil.which("ffmpeg"):
             subprocess.run(
                 [
                     "ffmpeg",


### PR DESCRIPTION
使用 #6 提到的 ffmpeg 合并视频。
并使用 tqdm 来显示进度条，同时支持断点续传。

试了一下，大概这个效果。
```log
❯ .\.venv\Scripts\python.exe .\main.py
マリーゴールド-万寿菊 /あいみょん【璃露】
下载的视频清晰度：清晰 480P
开始下载视频： マリーゴールド-万寿菊 あいみょん【璃露】.mp4
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 23.1M/23.1M [00:02<00:00, 11.5MB/s]
【下载视频完毕】
开始下载音频： マリーゴールド-万寿菊 あいみょん【璃露】.mp3
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.38M/7.38M [00:02<00:00, 3.01MB/s]
【下载音频完毕】
マリーゴールド-万寿菊 あいみょん【璃露】
ffmpeg version 7.0.2-full_build-www.gyan.dev Copyright (c) 2000-2024 the FFmpeg developers
built with gcc 13.2.0 (Rev5, Built by MSYS2 project)
configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libaribb24 --enable-libaribcaption --enable-libdav1d --enable-libdavs2 --enable-libuavs3d --enable-libxevd --enable-libzvbi --enable-librav1e --enable-libsvtav1 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxeve --enable-libxvid --enable-libaom --enable-libjxl --enable-libopenjpeg --enable-libvpx --enable-mediafoundation --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-liblensfun --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-libshaderc --enable-vulkan --enable-libplacebo --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libcodec2 --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
libavutil      59.  8.100 / 59.  8.100
libavcodec     61.  3.100 / 61.  3.100
libavformat    61.  1.100 / 61.  1.100
libavdevice    61.  1.100 / 61.  1.100
libavfilter    10.  1.100 / 10.  1.100
libswscale      8.  1.100 /  8.  1.100
libswresample   5.  1.100 /  5.  1.100
libpostproc    58.  1.100 / 58.  1.100
ffmpeg version 7.0.2-full_build-www.gyan.dev Copyright (c) 2000-2024 the FFmpeg developers
  built with gcc 13.2.0 (Rev5, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libaribb24 --enable-libaribcaption --enable-libdav1d --enable-libdavs2 --enable-libuavs3d --enable-libxevd --enable-libzvbi --enable-librav1e --enable-libsvtav1 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxeve --enable-libxvid --enable-libaom --enable-libjxl --enable-libopenjpeg --enable-libvpx --enable-mediafoundation --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-liblensfun --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-libshaderc --enable-vulkan --enable-libplacebo --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libcodec2 --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
  libavutil      59.  8.100 / 59.  8.100
  libavcodec     61.  3.100 / 61.  3.100
  libavformat    61.  1.100 / 61.  1.100
  libavdevice    61.  1.100 / 61.  1.100
  libavfilter    10.  1.100 / 10.  1.100
  libswscale      8.  1.100 /  8.  1.100
  libswresample   5.  1.100 /  5.  1.100
  libpostproc    58.  1.100 / 58.  1.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'C:\Users\hmy01\Works\Working\Tools\bilibili-downloader\temp\マリーゴールド-万寿菊 あいみょん【璃露】.mp4':
  Metadata:
    major_brand     : iso5
    minor_version   : 1
    compatible_brands: avc1iso5dsmsmsixdash
    encoder         : Lavf57.71.100
    description     : Packed by Bilibili XCoder v2.0.2
  Duration: 00:05:04.93, start: 0.000000, bitrate: 607 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 852x480 [SAR 640:639 DAR 16:9], 8 kb/s, 30 fps, 30 tbr, 16k tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
Input #1, mov,mp4,m4a,3gp,3g2,mj2, from 'C:\Users\hmy01\Works\Working\Tools\bilibili-downloader\temp\マリーゴールド-万寿菊 あいみょん【璃露】.mp3':
  Metadata:
    major_brand     : iso5
    minor_version   : 1
    compatible_brands: avc1iso5dsmsmsixdash
    encoder         : Lavf57.71.100
    description     : Packed by Bilibili XCoder v2.0.2
  Duration: 00:05:04.96, start: 0.031995, bitrate: 193 kb/s
  Stream #1:0[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 3 kb/s (default)
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
File 'C:\Users\hmy01\Works\Working\Tools\bilibili-downloader\output\銉炪儶銉笺偞銉笺儷銉?涓囧鑿?銇傘亜銇裤倗銈撱€愮拑闇层€?mp4' already exists. Overwrite? [y/N] y
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #1:0 -> #0:1 (copy)
Output #0, mp4, to 'C:\Users\hmy01\Works\Working\Tools\bilibili-downloader\output\マリーゴールド-万寿菊 あいみょん【璃露】.mp4':
  Metadata:
    major_brand     : iso5
    minor_version   : 1
    compatible_brands: avc1iso5dsmsmsixdash
    description     : Packed by Bilibili XCoder v2.0.2
    encoder         : Lavf61.1.100
  Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 852x480 [SAR 640:639 DAR 16:9], q=2-31, 8 kb/s, 30 fps, 30 tbr, 16k tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
  Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 3 kb/s (default)
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
Press [q] to stop, [?] for help
[out#0/mp4 @ 0000024d7b1d8a40] video:22480KiB audio:7147KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: 1.252064%
size=   29999KiB time=00:05:04.86 bitrate= 806.1kbits/s speed=4.24e+03x
视频合成结束
```