### PR TITLE
🐞 fix: resolve duplicate filename issue for multi-part videos

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,4 +15,7 @@ COOKIE = 'buvid3=C5DA0AE5-EE6D-EC73-9C00-91643BB46A8508801infoc; b_nut=166376580
 URL = [
     'https://www.bilibili.com/video/BV1M4411c7P4/?spm_id_from=333.999.0.0&vd_source=9c3224b88b8a3c4cc210fc6ff9b28f63',
     'https://www.bilibili.com/video/BV1hB4y147j8/?spm_id_from=333.337.search-card.all.click',
+    # 分 P 视频示例
+    'https://www.bilibili.com/video/BV1TnsZzHEcz?spm_id_from=333.788.videopod.episodes&vd_source=9c3224b88b8a3c4cc210fc6ff9b28f63',
+    'https://www.bilibili.com/video/BV1TnsZzHEcz?spm_id_from=333.788.videopod.episodes&vd_source=9c3224b88b8a3c4cc210fc6ff9b28f63&p=2'
 ]

--- a/models/video.py
+++ b/models/video.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse, parse_qs
 
 
 class Video():
@@ -6,6 +7,19 @@ class Video():
     def __init__(self, url: str, category: int) -> None:
         self.url = url
         self.category = category
+        # 从 URL 中提取分P参数（如果存在）
+        self.part_number = self._extract_part_number(url)
+
+    def _extract_part_number(self, url: str) -> int:
+        """从URL中提取分P参数，如果不存在则返回1"""
+        try:
+            parsed_url = urlparse(url)
+            query_params = parse_qs(parsed_url.query)
+            # 获取 p 参数，如果不存在则默认为 1
+            part = query_params.get('p', ['1'])[0]
+            return int(part)
+        except (ValueError, IndexError):
+            return 1
 
     def set_title(self, title: str) -> None:
         pattern = re.compile(r'[<>:"\/\\|\?\*]')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.9.3
 httpx==0.23.1
 moviepy==1.0.3
-requests==2.32.0
+requests==2.32.4
 urllib3==2.5.0
 tqdm==4.66.5

--- a/strategy/bilibili_executor.py
+++ b/strategy/bilibili_executor.py
@@ -78,8 +78,14 @@ class BilibiliDownloader():
         video_url = video.video_url
         audio_url = video.audio_url
 
-        video_filename = video.title + '.mp4'
-        audio_filename = video.title + '.mp3'
+        # 如果是分P视频（包括第1部分），在文件名中添加分P标识
+        # 这样可以避免多个分P之间的文件名冲突
+        if hasattr(video, 'part_number') and video.part_number >= 1:
+            video_filename = f'{video.title}_P{video.part_number}.mp4'
+            audio_filename = f'{video.title}_P{video.part_number}.mp3'
+        else:
+            video_filename = video.title + '.mp4'
+            audio_filename = video.title + '.mp3'
 
         # 创建文件夹存放下载的视频
         if not os.path.exists(self.temp_path):
@@ -146,8 +152,14 @@ class VideoMerge():
 
     def merge_video(self, video) -> None:
         print(video.title)
-        video_filename = video.title + '.mp4'
-        audio_filename = video.title + '.mp3'
+        # 如果是分P视频（包括第1部分），在文件名中添加分P标识
+        # 这样可以避免多个分P之间的文件名冲突
+        if hasattr(video, 'part_number') and video.part_number >= 1:
+            video_filename = f'{video.title}_P{video.part_number}.mp4'
+            audio_filename = f'{video.title}_P{video.part_number}.mp3'
+        else:
+            video_filename = video.title + '.mp4'
+            audio_filename = video.title + '.mp3'
 
         # 创建文件夹存放合并的视频
         if not os.path.exists(self.path):

--- a/strategy/default.py
+++ b/strategy/default.py
@@ -13,7 +13,8 @@ class DefaultStrategy(BilibiliStrategy):
 
     def __init__(self) -> None:
         super().__init__()
-        self.session = httpx.Client()
+        # 启用自动重定向
+        self.session = httpx.Client(follow_redirects=True)
         self.session.headers = {
             'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
             'accept-encoding': 'gzip, deflate, br',


### PR DESCRIPTION
## Summary

Fixes the duplicate filename issue when downloading multi-part (分P) videos from Bilibili. Previously, videos with the same title but different part numbers would overwrite each other because they generated identical filenames.

## Changes

- **models/video.py**: Added `part_number` attribute and URL parsing logic to extract the `p` parameter from video URLs
- **strategy/bilibili_executor.py**: Updated filename generation in both `BilibiliDownloader.download_video()` and `VideoMerge.merge_video()` to include part number suffix (e.g., `_P1.mp4`, `_P2.mp4`)
- **strategy/default.py**: Enabled `follow_redirects=True` for httpx client to handle URL redirects properly
- **requirements.txt**: Updated requests from 2.32.0 to 2.32.4 to address CVE-2024-35195
- **config.py**: Added multi-part video test URLs for validation

## Issue

#28 